### PR TITLE
Made heal scale with skill level, fixed item manager bug

### DIFF
--- a/CustomHeal.cs
+++ b/CustomHeal.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using UnityEngine;
+
+namespace TeqHealingStaff
+{
+    internal class SE_ScalingHeal : SE_Stats
+    {
+        public float baseHeal = -1f;
+        public Func<float, float> scalingFunction;
+
+        public static SE_ScalingHeal ConvertSEStatsToCustomHeal(SE_Stats stat, Func<float, float> scalingFunction, float healthOverTime = -1f, float healthOverTimeInterval = -1f, float healthOverTimeDuration = -1f)
+        {
+            SE_ScalingHeal customHeal = ScriptableObject.CreateInstance<SE_ScalingHeal>();
+
+            try
+            {
+                foreach (var field in typeof(SE_Stats).GetFields())
+                {
+                    field.SetValue(customHeal, field.GetValue(stat));
+                }
+
+                foreach (var field in typeof(StatusEffect).GetFields())
+                {
+                    field.SetValue(customHeal, field.GetValue(stat));
+                }
+
+                customHeal.name = stat.name;
+            }
+            catch (Exception)
+            {
+                Debug.LogError("Copying status effect failed.");
+            }
+
+            if (healthOverTimeInterval > 0f)
+            {
+                customHeal.m_healthOverTime = healthOverTime;
+            }
+
+            if (healthOverTimeInterval > 0f)
+            {
+                customHeal.m_healthOverTimeInterval = healthOverTimeInterval;
+            }
+
+            if (healthOverTimeDuration > 0f)
+            {
+                customHeal.m_healthOverTimeDuration = healthOverTimeDuration;
+            }
+
+            customHeal.baseHeal = customHeal.m_healthOverTime;
+            customHeal.scalingFunction = scalingFunction;
+
+            return customHeal;
+        }
+
+        public override void SetLevel(int itemLevel, float skillLevel)
+        {
+            base.SetLevel(itemLevel, skillLevel);
+
+            if (this.baseHeal > 0f && scalingFunction != null)
+            {
+                this.m_healthOverTime = this.baseHeal + scalingFunction(skillLevel);
+                RecalculateHealingStats();
+            }
+        }
+
+        // taken from SE_Stats.Setup
+        private void RecalculateHealingStats()
+        {
+            if (this.m_healthOverTime > 0f && this.m_healthOverTimeInterval > 0f)
+            {
+                if (this.m_healthOverTimeDuration <= 0f)
+                {
+                    this.m_healthOverTimeDuration = this.m_ttl;
+                }
+                this.m_healthOverTimeTicks = this.m_healthOverTimeDuration / this.m_healthOverTimeInterval;
+                this.m_healthOverTimeTickHP = this.m_healthOverTime / this.m_healthOverTimeTicks;
+            }
+        }
+    }
+}

--- a/ItemManager.cs
+++ b/ItemManager.cs
@@ -5,7 +5,6 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Text.RegularExpressions;
 using BepInEx;
 using BepInEx.Configuration;
 using HarmonyLib;
@@ -148,8 +147,9 @@ public class Item
 	private Configurability configurationVisible = Configurability.Full;
 
 	public readonly GameObject Prefab;
+    public readonly string DefaultEnglishName;
 
-	[Description("Specifies the resources needed to craft the item.\nUse .Add to add resources with their internal ID and an amount.\nUse one .Add for each resource type the item should need.")]
+    [Description("Specifies the resources needed to craft the item.\nUse .Add to add resources with their internal ID and an amount.\nUse one .Add for each resource type the item should need.")]
 	public RequiredResourceList RequiredItems => this[""].RequiredItems;
 
 	[Description("Specifies the resources needed to upgrade the item.\nUse .Add to add resources with their internal ID and an amount. This amount will be multipled by the item quality level.\nUse one .Add for each resource type the upgrade should need.")]
@@ -246,15 +246,15 @@ public class Item
 		}
 	}
 
-	public Item(string assetBundleFileName, string prefabName, string folderName = "assets") : this(PrefabManager.RegisterAssetBundle(assetBundleFileName, folderName), prefabName)
+	public Item(string assetBundleFileName, string prefabName, string sectionName, string folderName = "assets") : this(PrefabManager.RegisterAssetBundle(assetBundleFileName, folderName), prefabName, sectionName)
 	{
 	}
 
-	public Item(AssetBundle bundle, string prefabName) : this(PrefabManager.RegisterPrefab(bundle, prefabName, true), true)
+	public Item(AssetBundle bundle, string prefabName, string sectionName) : this(PrefabManager.RegisterPrefab(bundle, prefabName, true), true, sectionName)
 	{
 	}
 
-	public Item(GameObject prefab, bool skipRegistering = false)
+	public Item(GameObject prefab, bool skipRegistering, string sectionName)
 	{
 		if (!skipRegistering)
 		{
@@ -263,7 +263,8 @@ public class Item
 		Prefab = prefab;
 		registeredItems.Add(this);
 		itemDropMap[Prefab.GetComponent<ItemDrop>()] = this;
-	}
+        DefaultEnglishName = sectionName;
+    }
 
 	public void ToggleConfigurationVisibility(Configurability visible)
 	{
@@ -361,8 +362,8 @@ public class Item
 			foreach (Item item in registeredItems.Where(i => i.configurability != Configurability.Disabled))
 			{
 				string nameKey = item.Prefab.GetComponent<ItemDrop>().m_itemData.m_shared.m_name;
-				string englishName = new Regex("['[\"\\]]").Replace(english.Localize(nameKey), "").Trim();
-				string localizedName = Localization.instance.Localize(nameKey).Trim();
+				string englishName = item.DefaultEnglishName;
+                string localizedName = Localization.instance.Localize(nameKey).Trim();
 
 				if ((item.configurability & Configurability.Recipe) != 0)
 				{

--- a/TeqHealingStaff.csproj
+++ b/TeqHealingStaff.csproj
@@ -95,6 +95,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CustomHeal.cs" />
     <Compile Include="ItemManager.cs" />
     <Compile Include="Plugin.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
- you can change how much the heal scales by changing the ScalingHealFunction method (currently skill level / 5 for this staff, can be different for different status effects/ staves)
- you can also change the base heal stats as optional parameters of the line if you want to not do it unity:
`var customHeal = SE_ScalingHeal.ConvertSEStatsToCustomHeal(se_stats, ScalingHealFunction);`